### PR TITLE
Actually use storage constructor arguments.

### DIFF
--- a/b2_storage/storage.py
+++ b/b2_storage/storage.py
@@ -9,10 +9,14 @@ from .backblaze_b2 import BackBlazeB2
 
 class B2Storage(Storage):
     def __init__(self, account_id=None, app_key=None, bucket_name=None):
-        self.account_id = settings.BACKBLAZEB2_ACCOUNT_ID  # if account_id == None
-        self.app_key = settings.BACKBLAZEB2_APP_KEY  # if app_key == None
-        self.bucket_name = settings.BACKBLAZEB2_BUCKET_NAME  # if bucket_name == None
-        self.b2 = BackBlazeB2(app_key=self.app_key, account_id=self.account_id, bucket_name=self.bucket_name)
+        overrides = locals()
+        defaults = {
+            'account_id': settings.BACKBLAZEB2_ACCOUNT_ID,
+            'app_key': settings.BACKBLAZEB2_APP_KEY,
+            'bucket_name': settings.BACKBLAZEB2_BUCKET_NAME,
+        }
+        kwargs = {k: overrides[k] or v for k, v in defaults.items()}
+        self.b2 = BackBlazeB2(**kwargs)
 
     def save(self, name, content, max_length=None):
         """

--- a/b2_storage/storage.py
+++ b/b2_storage/storage.py
@@ -4,9 +4,12 @@ from io import BytesIO
 from django.conf import settings
 from django.core.files.storage import Storage
 from django.core.files.base import File
+from django.utils.deconstruct import deconstructible
+
 from .backblaze_b2 import BackBlazeB2
 
 
+@deconstructible
 class B2Storage(Storage):
     def __init__(self, account_id=None, app_key=None, bucket_name=None):
         overrides = locals()


### PR DESCRIPTION
Storage arguments were never used, thus making it impossible to work with multiple accounts or, more importantly, multiple buckets.